### PR TITLE
Fix logrotate.j2 template by adding endscript to postrotate

### DIFF
--- a/templates/pgbouncer/logrotate.j2
+++ b/templates/pgbouncer/logrotate.j2
@@ -9,5 +9,5 @@
     create 0644 {{ pgbouncer.user }} {{ pgbouncer.group }}
     postrotate
         /etc/init.d/pgbouncer reload
-
+    endscript
 }


### PR DESCRIPTION
This error caused logrotate not to work with error:

```
reading config file postgresql-common
error: postgresql-common:prerotate, postrotate or preremove without endscript
error: found error in file postgresql-common, skipping
```
